### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ If JIRA ticket for a security update already exists it will not be recreated.
 2. Configure the tool with environment variables or an `.env` file. The
    following keys are supported:
 
-   - `HOST`: The host name of the Drupal site to check, e.g. `reload.dk`
+   - `DRUPAL_HOST`: The host name of the Drupal site to check, e.g. `reload.dk`
      (**REQUIRED**)
-   - `TOKEN`: The token used to retrieve data exposed by the System Status
-     module. This is the part of the site UUID before the `-` as reported on
-     <https://reload.dk/admin/config/system/system-status> (**REQUIRED**)
-   - `KEY`: The key used to decrypt data exposed by the System Status module
-     (**REQUIRED**). This is the part of the site UUID before the `-` as
-     reported on <https://foo.com/admin/config/system/system-status>
+   - `SYSTEM_STATUS_TOKEN`: The token used to retrieve data exposed by the
+     System Status module. This is the part of the site UUID before the `-` as
+     reported on <https://reload.dk/admin/config/system/system-status>
+     (**REQUIRED**)
+   - `SYSTEM_STATUS_KEY`: The key used to decrypt data exposed by the System
+     Status module (**REQUIRED**). This is the part of the site UUID before the
+     `-` as reported on <https://foo.com/admin/config/system/system-status>
    - `JIRA_HOST`: The endpoint for your JIRA instance, e.g.
      <https://reload.atlassian.net> (**REQUIRED**)
    - `JIRA_USER`: The ID of the JIRA user which is associated with `JIRA_TOKEN`
@@ -43,6 +44,7 @@ If JIRA ticket for a security update already exists it will not be recreated.
      Defaults to `Developers`. (*Optional*)
    - `DRY_RUN`: Do not actually create any tickets but report that they would be
      created. Defaults to `FALSE`. (*Optional*)
+
 3. Run `./bin/drupal-security-jira sync`
 
 ## Setup on GitHub Actions
@@ -64,10 +66,10 @@ in the repo:
 
 1. `JiraApiToken` containing an [API Token](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)
    for the JIRA user that should be used to create tickets.
-2. `Token` containing the part of the site UUID before the `-` as reported on
-   `/admin/config/system/system-status`
-3. `Key` containing the part of the site UUID after the `-` as reported on
-   `/admin/config/system/system-status`
+2. `SystemStatusToken` containing the part of the site UUID before the `-` as
+   reported on `/admin/config/system/system-status`
+3. `SystemStatusKey` containing the part of the site UUID after the `-` as
+   reported on `/admin/config/system/system-status`
 
 ### Workflow file setup
 
@@ -90,9 +92,9 @@ jobs:
       - name: "Sync JIRA security issues from Drupal security updates"
         uses: reload/github-security-jira
         env:
-          HOST: reload.dk
-          TOKEN: ${{ secrets.Token }}
-          KEY: ${{ secrets.Key }}
+          DRUPAL_HOST: reload.dk
+          SYSTEM_STATUS_TOKEN: ${{ secrets.Token }}
+          SYSTEM_STATUS_KEY: ${{ secrets.Key }}
           JIRA_TOKEN: ${{ secrets.JiraApiToken }}
           JIRA_HOST: https://reload.atlassian.net
           JIRA_USER: someuser@reload.dk

--- a/src/DrupalOrg/VersionGroup.php
+++ b/src/DrupalOrg/VersionGroup.php
@@ -41,7 +41,7 @@ class VersionGroup
         );
 
         $nextVersions = Semver::sort($nextVersions);
-        $nextVersion = current(array_keys($nextVersions));
+        $nextVersion = current($nextVersions);
         if (!is_string($nextVersion)) {
             throw new \RuntimeException("Unexpected value for next version $nextVersion.");
         }

--- a/src/DrupalOrg/VersionGroup.php
+++ b/src/DrupalOrg/VersionGroup.php
@@ -21,7 +21,7 @@ class VersionGroup
 
     private function normalizeVersion(string $version): string
     {
-        return preg_replace('/^\d\.x\-/', '', $version);
+        return preg_replace('/^\d\.(\d\.)?x\-/', '', $version);
     }
 
     public function getNextVersion(string $currentVersion): string

--- a/src/SyncCommand.php
+++ b/src/SyncCommand.php
@@ -23,12 +23,12 @@ class SyncCommand extends Command
         // getenv() which is used by reload/jira-security-issue.
         $env = Dotenv::createUnsafeImmutable(__DIR__ . '/../');
         $env->safeLoad();
-        $env->required(['HOST', 'TOKEN', 'KEY'])->notEmpty();
+        $env->required(['DRUPAL_HOST', 'SYSTEM_STATUS_TOKEN', 'SYSTEM_STATUS_KEY'])->notEmpty();
         $env->ifPresent('DRY_RUN')->isBoolean();
 
-        $host = getenv('HOST', true) ?: '';
-        $token = getenv('TOKEN', true) ?: '';
-        $key = getenv('KEY', true) ?: '';
+        $host = getenv('DRUPAL_HOST', true) ?: '';
+        $token = getenv('SYSTEM_STATUS_TOKEN', true) ?: '';
+        $key = getenv('SYSTEM_STATUS_KEY', true) ?: '';
         $dry_run = (bool) getenv('DRY_RUN', true);
 
         $logger = new ConsoleLogger($output);


### PR DESCRIPTION
- Rename variables to make their purpose more telling
- Fix retrieval of next secure version
- Handle Drupal Core minor releases included in version numbers
- Only consider projects where we can recognize the version
