### PR TITLE
List projects with no known version

### DIFF
--- a/src/SyncCommand.php
+++ b/src/SyncCommand.php
@@ -45,6 +45,15 @@ class SyncCommand extends Command
         $projectVersionMap = $data->getProjectVersionMap();
         $logger->debug("Retrieved projects: {projects}", ['projects' => print_r($projectVersionMap, true)]);
 
+        // Log projects with no known version.
+        $unknownProjects = array_filter($projectVersionMap, 'is_null');
+        $logger->notice('Projects with no known version: {projects}', [
+            'projects' => print_r(array_keys($unknownProjects), true),
+        ]);
+
+        // Filter away projects with no known version.
+        $projectVersionMap = array_filter($projectVersionMap);
+
         $projectFetcher = new ProjectFetcher(HttpClient::create());
 
         $filters = [

--- a/src/SystemStatus/SiteData.php
+++ b/src/SystemStatus/SiteData.php
@@ -19,7 +19,7 @@ class SiteData
     }
 
     /**
-     * @return string[]
+     * @return array<string, string|null>
      */
     public function getProjectVersionMap(): array
     {
@@ -43,6 +43,6 @@ class SiteData
             ARRAY_FILTER_USE_BOTH
         );
 
-        return array_filter($filteredVersionMap);
+        return $filteredVersionMap;
     }
 }


### PR DESCRIPTION
It could be an indication of a problem, since we cannot determine if they need to be updated. Or they could be custom modules which we have no way of identifying.

Example from reload.dk:
```
(
    [card] => 
    [daterange_compact] => 
    [file_entity_download_link] => 
    [multimedia_list] => 
    [reload_activecampaign] => 
    [reload_admin] => 
    [reload_base] => 
    [reload_cookiebot] => 
    [reload_language] => 
    [reload_update] => 
    [views_daterange_filters] => 
    [refreshing] => 
)
```