### PR TITLE
Fix logic for selecting recommended secure version

### DIFF
--- a/src/DrupalOrg/ProjectFetcher.php
+++ b/src/DrupalOrg/ProjectFetcher.php
@@ -107,7 +107,7 @@ class ProjectFetcher
         $secureVersion = new VersionGroup(
             $this->getSecureVersions($project, $drupalVersion)
         );
-        return $secureVersion->getNextVersion($version);
+        return $secureVersion->getNextVersion($version, ($project !== 'drupal'));
     }
 
     /**

--- a/src/DrupalOrg/VersionGroup.php
+++ b/src/DrupalOrg/VersionGroup.php
@@ -45,7 +45,7 @@ class VersionGroup
         $nextVersions = array_filter(
             $normalizedVersions,
             function (string $version) use ($normalizedCurrentVersion): bool {
-                return Comparator::greaterThanOrEqualTo($version, $normalizedCurrentVersion);
+                return Comparator::greaterThan($version, $normalizedCurrentVersion);
             }
         );
 

--- a/src/DrupalOrg/VersionGroup.php
+++ b/src/DrupalOrg/VersionGroup.php
@@ -33,7 +33,7 @@ class VersionGroup
         return str_replace($normalizedReference, $normalizedVersion, $referenceVersion);
     }
 
-    public function getNextVersion(string $currentVersion): string
+    public function getNextVersion(string $currentVersion, bool $bumpMajor = true): string
     {
         $versions = array_combine($this->versions, $this->versions);
 
@@ -48,6 +48,10 @@ class VersionGroup
                 return Comparator::greaterThan($version, $normalizedCurrentVersion);
             }
         );
+
+        if (!$bumpMajor) {
+            $nextVersions = Semver::satisfiedBy($nextVersions, "^${normalizedCurrentVersion}");
+        }
 
         $nextVersions = Semver::rsort($nextVersions);
         $nextVersion = current($nextVersions);

--- a/src/DrupalOrg/VersionGroup.php
+++ b/src/DrupalOrg/VersionGroup.php
@@ -49,7 +49,7 @@ class VersionGroup
             }
         );
 
-        $nextVersions = Semver::sort($nextVersions);
+        $nextVersions = Semver::rsort($nextVersions);
         $nextVersion = current($nextVersions);
         if (!is_string($nextVersion)) {
             throw new \RuntimeException("Unexpected value for next version $nextVersion.");


### PR DESCRIPTION
- Only select version actually greater than the current
- Reverse sort secure versions
- Don't bump major version when picking secure Drupal core

I recommend looking at the commits one by one to understand the details.