### PR TITLE
Tag modules with no known secure version as 'unknown' and support other URL schemes

### DIFF
--- a/src/DrupalOrg/VersionGroup.php
+++ b/src/DrupalOrg/VersionGroup.php
@@ -22,6 +22,8 @@ use function Safe\preg_replace;
 class VersionGroup
 {
 
+    public const UNKNOWN_VERSION = 'unknown';
+
     /**
      * @param string[] $versions
      */
@@ -77,10 +79,8 @@ class VersionGroup
      *   The given version.
      *
      * @return string
-     *   The closest match to the provided version.
-     *
-     * @throws \RuntimeException
-     *   If a match cannot be determined.
+     *   The closest match to the provided version. If no match could
+     *   be found, it returns the string 'unknown'.
      */
     public function getNextVersion(string $currentVersion): string
     {
@@ -98,7 +98,7 @@ class VersionGroup
         $sortedVersions = Semver::sort(array_keys($nextVersions));
         $nextVersion = current($sortedVersions);
         if (!is_string($nextVersion)) {
-            throw new \RuntimeException("Unexpected value for next version $nextVersion.");
+            return self::UNKNOWN_VERSION;
         }
 
         return $nextVersions[$nextVersion];

--- a/src/SystemStatus/Fetcher.php
+++ b/src/SystemStatus/Fetcher.php
@@ -7,6 +7,7 @@ namespace DrupalSecurityJira\SystemStatus;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 use function Safe\json_decode;
+use function Safe\parse_url;
 
 class Fetcher
 {
@@ -21,7 +22,14 @@ class Fetcher
 
     public function fetch(): SiteData
     {
-        $url = "https://{$this->host}/admin/reports/system_status/{$this->token}";
+        $host = $this->host;
+
+        // Add a URL scheme if none is present.
+        if (!is_string(parse_url($host, PHP_URL_SCHEME))) {
+            $host = "https://{$host}";
+        }
+
+        $url = "{$host}/admin/reports/system_status/{$this->token}";
         $response = $this->client->request("GET", $url);
         $data = json_decode($response->getContent());
 

--- a/tests/DrupalOrg/VersionGroupTest.php
+++ b/tests/DrupalOrg/VersionGroupTest.php
@@ -36,7 +36,7 @@ class VersionGroupTest extends TestCase
             'Fails when unable to determine version' => [
                 ["1.0.0"],
                 "1.1.0",
-                null,
+                VersionGroup::UNKNOWN_VERSION,
             ],
             'Legacy Drupal versions' => [
                 ["7.x-1.0", "7.x-1.1", "7.x-1.2", "7.x-1.3"],


### PR DESCRIPTION
The 'unknown' string will be used in the Jira labels.

This actually happens on VGS where we use remote_stream_wrapper in the insecure version 7.x-1.0 and there is no secure version.

Throwing an error also stops processing and would miss later modules, so we would at least need to just log a warning and proceed.

Also support specifying a URL scheme instead of assuming HTTPS.