### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,7 @@
 on: pull_request
 name: Check and lint
+permissions:
+  contents: read
 
 jobs:
   php_version:


### PR DESCRIPTION
Potential fix for [https://github.com/reload/drupal-security-jira/security/code-scanning/7](https://github.com/reload/drupal-security-jira/security/code-scanning/7)

The best way to fix this issue is to set a minimal permissions block for the entire workflow (at the root), unless individual jobs require specific broader permissions. For this workflow, all jobs appear to operate fine with read-only access to the repository contents—none of them require write permissions to issues, pull requests, or other resources. The recommended block is:
```yaml
permissions:
  contents: read
```
This should be added after the `name:` line and before the `jobs:` line—i.e., on line 3. This makes the workflow explicit about its minimal required permissions and adheres to GitHub's least privilege principle.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
