### PR TITLE
Retry HTTP requests with exponential backoff

### DIFF
--- a/src/SyncCommand.php
+++ b/src/SyncCommand.php
@@ -7,12 +7,16 @@ namespace DrupalSecurityJira;
 use Dotenv\Dotenv;
 use DrupalSecurityJira\DrupalOrg\ProjectFetcher;
 use DrupalSecurityJira\SystemStatus\Fetcher;
+use Psr\Log\LoggerInterface;
 use Reload\JiraSecurityIssue;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
+use Symfony\Component\HttpClient\RetryableHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class SyncCommand extends Command
 {
@@ -34,7 +38,7 @@ class SyncCommand extends Command
 
         $logger->debug("Fetching data from {$host}");
         $fetcher = new Fetcher(
-            HttpClient::create(),
+            $this->createHttpClient($logger),
             $host,
             $token,
             $key
@@ -53,7 +57,7 @@ class SyncCommand extends Command
         // Filter away projects with no known version.
         $projectVersionMap = array_filter($projectVersionMap);
 
-        $projectFetcher = new ProjectFetcher(HttpClient::create());
+        $projectFetcher = new ProjectFetcher($this->createHttpClient($logger));
 
         $filters = [
             "Identify projects on Drupal.org" =>
@@ -118,5 +122,18 @@ EOT;
         }, array_keys($securedProjectsVersionMap), $securedProjectsVersionMap);
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Create an HTTP client that retries failed requests with exponential
+     * backoff, retrying up to 3 times before giving up.
+     */
+    private function createHttpClient(LoggerInterface $logger): HttpClientInterface
+    {
+        // GenericRetryStrategy defaults to a 1000ms initial delay and a
+        // multiplier of 2.0, i.e. exponential backoff (1s, 2s, 4s, ...).
+        $strategy = new GenericRetryStrategy();
+
+        return new RetryableHttpClient(HttpClient::create(), $strategy, 3, $logger);
     }
 }


### PR DESCRIPTION
## Summary

Failed HTTP requests are now retried automatically using exponential backoff, retrying up to 3 times before giving up.

This project uses Symfony HTTP Client (not Guzzle), so the retry behaviour is added by wrapping both HTTP clients in Symfony's built-in `RetryableHttpClient` decorator.

## Details

- New `SyncCommand::createHttpClient()` helper wraps `HttpClient::create()` in a `RetryableHttpClient`.
- Uses `GenericRetryStrategy`, whose defaults give exponential backoff (~1s, 2s, 4s, with ±10% jitter), with `maxRetries` set to **3**.
- The command logger is passed in, so retries are logged.
- Both the `Fetcher` (system status) and `ProjectFetcher` (drupal.org) clients use it.

By default the strategy retries on transport errors (timeouts, connection failures) and retryable HTTP status codes (423, 425, 429, 500, 502, 503, 504, 507, 510).

## Testing

- PHPStan ✔
- PHPCS ✔
- PHPUnit (8 tests) ✔